### PR TITLE
Fixed typographical error, changed Ceasar to Caesar in README.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -4,7 +4,7 @@ Ruby implementation of some classic encryption algorithms.
 
 == Current Encryption Algorithms
 
-* Ceasar Cipher (the "Hellow World" of encryption)
+* Caesar Cipher (the "Hellow World" of encryption)
 
 Hopefully there will be more to come...
 


### PR DESCRIPTION
LupineDev, I've corrected a typographical error in the documentation of the [lupine_crypto](https://github.com/LupineDev/lupine_crypto) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
